### PR TITLE
Update hosts.json

### DIFF
--- a/src/hosts.json
+++ b/src/hosts.json
@@ -2737,8 +2737,8 @@
     "pi-slug": "zencastr.com"
   },
   {
-    "pattern": "api.riverside.fm",
-    "rss-pattern": "api.riverside.fm",
+    "pattern": "riverside.fm",
+    "rss-pattern": "riverside.fm",
     "hostname": "Riverside",
     "retailer": "1",
     "iab": "0",


### PR DESCRIPTION
Relax Riverside's definition. Currently feeds are at api.riverside.fm and api.stg.riverside.fm